### PR TITLE
Adding rsa signing functions

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -6,7 +6,8 @@
                ("base" #:version "6.10")
                "typed-racket-lib"
                "typed-racket-more"
-               "sha"))
+               "sha"
+               "crypto"))
 
 (define build-deps
   '("rackunit-lib" "web-server-lib" "racket-doc" "scribble-lib"

--- a/net/jwt/algorithms.rkt
+++ b/net/jwt/algorithms.rkt
@@ -2,6 +2,17 @@
 
 (require "base64.rkt")
 
+(require/typed crypto
+  [#:opaque Pk-Key pk-key?]
+  [#:opaque Crypto-Factory crypto-factory?]
+  [crypto-factories (Parameter (List Crypto-Factory))]
+  [datum->pk-key (-> Bytes Symbol Crypto-Factory Pk-Key)]
+  [digest (-> Symbol Bytes Bytes)]
+  [pk-sign (-> Pk-Key Bytes #:pad Symbol #:digest Symbol Bytes)])
+
+(require/typed crypto/libcrypto
+  [libcrypto-factory Crypto-Factory])
+
 (require/typed sha
                [#:opaque Lib-SHA256 sha256?]
                [#:opaque Lib-SHA384 sha384?]
@@ -22,7 +33,8 @@
          current-string-converter
          SigningFunction
          ok-signature?
-         none hs256 hs384 hs512
+         none hs256 hs384 hs512 rs256
+         rs256 rs384 rs512
          supported?
          signing-function
          SHA256 SHA384 SHA512)
@@ -61,6 +73,27 @@
 (: hs512 SigningFunction)
 (define (hs512 secret message) (hmac-sha512 (as-bytes secret) (as-bytes message)))
 
+(: rs256 SigningFunction)
+(define (rs256 secret message)
+  (rsa-sign 'sha256 secret message))
+
+(: rs384 SigningFunction)
+(define (rs384 secret message)
+  (rsa-sign 'sha384 secret message))
+
+(: rs512 SigningFunction)
+(define (rs512 secret message)
+  (rsa-sign 'sha512 secret message))
+
+(: rsa-sign (-> Symbol SorB SorB Bytes))
+(define (rsa-sign digester secret message)
+  (parameterize ((crypto-factories (list libcrypto-factory)))
+    (pk-sign
+     (datum->pk-key (as-bytes secret) 'PrivateKeyInfo libcrypto-factory)
+     (digest digester (as-bytes message))
+     #:pad 'pkcs1-v1.5
+     #:digest digester)))
+
 (: as-bytes (SorB -> Bytes))
 (define (as-bytes s/b) (if (bytes? s/b) s/b ((current-string-converter) s/b)))
 
@@ -71,7 +104,7 @@
 ;; containing only the name of one of the "alg" header parameter values from
 ;; the JWA RFC Section 3.1.
 (: supported-algorithms (Listof String))
-(define supported-algorithms '("none" "HS256" "HS384" "HS512"))
+(define supported-algorithms '("none" "HS256" "HS384" "HS512" "RS256" "RS384" "RS512"))
 
 (: supported? ((U Symbol String) -> Boolean))
 (define (supported? alg-name)
@@ -80,7 +113,7 @@
     (string-ci=? alg alg-name/s)))
 
 (: signing-functions (Listof SigningFunction))
-(define signing-functions (list none hs256 hs384 hs512))
+(define signing-functions (list none hs256 hs384 hs512 rs256 rs384 rs512))
 
 (: algorithm-table (HashTable (U Symbol String) SigningFunction))
 (define algorithm-table

--- a/net/jwt/algorithms.rkt
+++ b/net/jwt/algorithms.rkt
@@ -33,7 +33,7 @@
          current-string-converter
          SigningFunction
          ok-signature?
-         none hs256 hs384 hs512 rs256
+         none hs256 hs384 hs512
          rs256 rs384 rs512
          supported?
          signing-function

--- a/net/jwt/encode-decode.rkt
+++ b/net/jwt/encode-decode.rkt
@@ -59,7 +59,7 @@ Decodes the given Compact JWS Serialization, producing an unverified JWT.
                       (jshash->claims claims) payload-string
                       signature))))
 
-(: verify-jwt (->* (JWT String String)
+(: verify-jwt (->* (JWT String (U String Bytes))
                    (#:aud (Option String)
                     #:iss (Option String)
                     #:clock-skew Exact-Nonnegative-Integer)
@@ -103,7 +103,7 @@ the given secret and is intended for the given audience.
          (ok-signature? sig secret (string-append rh "." payload) sign)
          (verified-jwt header rh claims payload sig))))
 
-(: decode/verify (->* (String String String)
+(: decode/verify (->* (String String (U String Bytes))
                       (#:aud (Option String)
                        #:iss (Option String)
                        #:clock-skew Exact-Nonnegative-Integer)
@@ -213,7 +213,7 @@ the given secret and is intended for the given audience.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Encoding
 
-(: encode/sign (->* (String String)
+(: encode/sign (->* (String (U String Bytes))
                     (#:extra-headers (HashTable Symbol JSExpr)
                      #:iss (Option String)
                      #:sub (Option String)

--- a/net/jwt/jwt.scrbl
+++ b/net/jwt/jwt.scrbl
@@ -289,10 +289,14 @@ names specified in RFC 7519 @cite["RFC7519"].
 
 @defmodule[net/jwt/algorithms]{
   Provides functions related to signing JWTs and verifying JWT signatures.
-  Currently the only supported algorithms are HMAC-SHA256, HMAC-SHA384, and
-  HMAC-SHA512 — via the @racket[sha] package's @racket[hmac-sha256],
-  @racket[hmac-sha384], and @racket[hmac-sha512], respectively — and the
-  no-op algorithm @racket[none] (see RFC7515 Appendix A.5 @cite["RFC7515"]).
+  Currently the only supported algorithms are
+  @itemlist[
+    @item{HMAC-SHA256, HMAC-SHA384, and  HMAC-SHA512 — via the @racket[sha] package's @racket[hmac-sha256],
+          @racket[hmac-sha384], and @racket[hmac-sha512], respectively.}
+    @item{the  no-op algorithm @racket[none] (see RFC7515 Appendix A.5 @cite["RFC7515"]).}
+    @item{RSASSA-PKCS1-v1_5 with the SHA-256, SHA-384 and SHA-512 using the @racket[crypto] package.}
+  ]
+
   Any additional algorithms that may be implemented in future will be
   accessible via a @racket[SigningFunction] defined in this module.
 

--- a/tests/net/jwt/algorithms.rkt
+++ b/tests/net/jwt/algorithms.rkt
@@ -2,7 +2,22 @@
 
 (require typed/rackunit
          net/jwt/algorithms
-         net/jwt/base64)
+         net/jwt/base64
+         )
+
+(require/typed crypto
+  [#:opaque Pk-Key pk-key?]
+  [#:opaque Crypto-Factory crypto-factory?]
+  [generate-private-key (-> Symbol (List Any) Pk-Key)]
+  [crypto-factories (Parameter (List Crypto-Factory))]
+  [digest (-> Symbol Bytes Bytes)]
+  [pk-key->datum (-> Pk-Key Symbol Bytes)]
+  [pk-key->public-only-key (-> Pk-Key Pk-Key)]
+  [pk-verify (-> Pk-Key Bytes Bytes #:pad Symbol #:digest Symbol Boolean)]
+  [pk-sign (-> Pk-Key Bytes #:pad Symbol #:digest Symbol Bytes)])
+
+(require/typed crypto/libcrypto
+  [libcrypto-factory Crypto-Factory])
 
 (define sig1 "TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ")
 (define secret1 "secret")
@@ -23,3 +38,20 @@
 (check-true (supported? "none"))
 (check-true (supported? "HS256"))
 (check-false (supported? "HS257"))
+
+;; RS algorithms
+
+(parameterize ((crypto-factories (list libcrypto-factory)))
+  (define key-pair 
+    (generate-private-key 'rsa '((nbits 2048))))
+  (define public-key (pk-key->public-only-key key-pair))
+  (check-true (supported? "RS256"))
+  (check-true (pk-verify 
+               public-key
+               (digest 'sha256 (string->bytes/latin-1 msg1))
+               (rs256 (pk-key->datum key-pair 'PrivateKeyInfo) (string->bytes/latin-1 msg1))
+               #:digest 'sha256
+               #:pad 'pkcs1-v1.5)))
+             
+                       
+


### PR DESCRIPTION
Extending this package to include 3 new signing functions: RS256, RS384 and RS512. 

I am using the pk-sign procedure provided by the crypto module. Had to tweak the signatures of the high-level interface to allow bytes for secrets. 